### PR TITLE
Updated the GCC version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ HDF5 requires CMake >= 3.1.0
 
 % module load git/2.11.0
 
-% module load gcc/5.3.0
+% module load gcc/7.3.0
 
 % module load openmpi/1.10.5
 


### PR DESCRIPTION
With C++17, FleCSI needs GCC 7 to compile and build. 
Updating the README for GCC version to have the module loaded consistent.